### PR TITLE
Allow to open directories with xdg-open

### DIFF
--- a/harbour-file-browser.desktop
+++ b/harbour-file-browser.desktop
@@ -9,11 +9,13 @@ Type=Application
 X-Nemo-Application-Type=silica-qt5
 Name=File Browser
 Icon=harbour-file-browser
-Exec=harbour-file-browser
+Exec=harbour-file-browser %F
 Categories=System;FileTools;FileManager
+MimeType=inode/directory
 
 # Translators: the name has to be short enough not to be abbreviated
 # by the system (launcher view).
 Name[en]=File Browser
 Name[fi]=Tiedostoselain
 Name[de]=Dateiverwaltung
+Name[pl]=Pliki


### PR DESCRIPTION
(...and while being here, translate app name to Polish)

Since `harbour-file-browser` is already prepared to take a directory path as a command-line argument, this allows other apps (like SearchNemo) to use e.g. `xdg-open /home/nemo/Downloads`, and it will by default ask the user for the preferred app, and open the correct directory in File Browser instead of the stock WWW browser, which is normally the only associated with directories.

On desktop Linux distros, apps like Nautilus, Dolphin or other file browsers also have such association.

See https://github.com/sailfishos/sailfish-office/blob/fdf5a30468f0b79ac975f2215abf3e51b435e3df/sailfish-office-openfile.desktop#L10 for an example from core sailfish.
See karip#34 for the feature discussion in legacy File Browser 1.x.

I chose %F instead of %U, because `harbour-file-browser file:///home/nemo/Downloads` does not currently work.