### PR TITLE
en: full stop → dot

### DIFF
--- a/qml/pages/GlobalSettingsPage.qml
+++ b/qml/pages/GlobalSettingsPage.qml
@@ -103,7 +103,7 @@ Page {
                     SettingsSwitch {
                         text: qsTr("Show hidden files")
                         key: "viewHiddenFilesShown"
-                        description: qsTr('Show files with names starting with a full stop (“.”).')
+                        description: qsTr('Show files with names starting with a dot (“.”).')
                     }
                     SettingsSwitch {
                         text: qsTr("Show preview images")
@@ -144,7 +144,7 @@ Page {
                     SettingsSwitch {
                         text: qsTr("Show hidden files last")
                         key: "viewShowHiddenLast"
-                        description: qsTr("Always show files starting with a full stop (“.”) at the end of the file list.")
+                        description: qsTr("Always show files starting with a dot (“.”) at the end of the file list.")
                     }
                     ComboBox {
                         label: qsTr("Sort by")

--- a/qml/pages/ViewSettingsPage.qml
+++ b/qml/pages/ViewSettingsPage.qml
@@ -129,7 +129,7 @@ Page {
             SettingsSwitch {
                 text: qsTr("Show hidden files")
                 key: "viewHiddenFilesShown"
-                description: qsTr('Show files with names starting with a full stop (“.”).')
+                description: qsTr('Show files with names starting with a dot (“.”).')
                 settingsContainer: prefs
             }
             SettingsSwitch {
@@ -166,7 +166,7 @@ Page {
             SettingsSwitch {
                 text: qsTr("Show hidden files last")
                 key: "viewShowHiddenLast"
-                description: qsTr("Always show files starting with a full stop (“.”) at the end of the file list.")
+                description: qsTr("Always show files starting with a dot (“.”) at the end of the file list.")
                 settingsContainer: prefs
             }
         }

--- a/translations/harbour-file-browser-ab.ts
+++ b/translations/harbour-file-browser-ab.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3427,7 +3427,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3467,7 +3467,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-be.ts
+++ b/translations/harbour-file-browser-be.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3463,7 +3463,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3503,7 +3503,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-cs.ts
+++ b/translations/harbour-file-browser-cs.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3465,7 +3465,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3505,7 +3505,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-de.ts
+++ b/translations/harbour-file-browser-de.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Dateien anzeigen, deren Name mit einem Punkt beginnt („.“).</translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Dateien, deren Name mit einem Punkt („.“) beginnt, immer zuunterst in der Dateiliste anzeigen.</translation>
     </message>
     <message>
@@ -3432,7 +3432,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Dateien anzeigen, deren Name mit einem Punkt beginnt („.“).</translation>
     </message>
     <message>
@@ -3472,7 +3472,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Dateien, deren Name mit einem Punkt („.“) beginnt, immer zuunterst in der Dateiliste anzeigen.</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-el.ts
+++ b/translations/harbour-file-browser-el.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3427,7 +3427,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3467,7 +3467,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-en.ts
+++ b/translations/harbour-file-browser-en.ts
@@ -1268,8 +1268,8 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
-        <translation>Show files with names starting with a full stop (“.”).</translation>
+        <source>Show files with names starting with a dot (“.”).</source>
+        <translation>Show files with names starting with a dot (“.”).</translation>
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="109"/>
@@ -1328,8 +1328,8 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
-        <translation>Always show files starting with a full stop (“.”) at the end of the file list.</translation>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
+        <translation>Always show files starting with a dot (“.”) at the end of the file list.</translation>
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="150"/>
@@ -3429,8 +3429,8 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
-        <translation>Show files with names starting with a full stop (“.”).</translation>
+        <source>Show files with names starting with a dot (“.”).</source>
+        <translation>Show files with names starting with a dot (“.”).</translation>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="136"/>
@@ -3469,8 +3469,8 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
-        <translation>Always show files starting with a full stop (“.”) at the end of the file list.</translation>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
+        <translation>Always show files starting with a dot (“.”) at the end of the file list.</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-file-browser-es.ts
+++ b/translations/harbour-file-browser-es.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Muestra los archivos cuyos nombres empiecen por un punto (&quot;.&quot;).</translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Muestra siempre los archivos que empiezan por un punto (&quot;.&quot;) al final de la lista de archivos.</translation>
     </message>
     <message>
@@ -3429,7 +3429,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Muestra los archivos cuyos nombres empiecen por un punto (&quot;.&quot;).</translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Muestra siempre los archivos que empiezan por un punto (&quot;.&quot;) al final de la lista de archivos.</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-et.ts
+++ b/translations/harbour-file-browser-et.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Näita faile, mille nime alguses on punkt („.“).</translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Näita punktiga („.“) algavaid faile ehk peidetud faile alati loendi lõpus.</translation>
     </message>
     <message>
@@ -3429,7 +3429,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Näita faile, mille nime alguses on punkt („.“).</translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Näita punktiga („.“) algavaid faile ehk peidetud faile alati loendi lõpus.</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-fi.ts
+++ b/translations/harbour-file-browser-fi.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Näytä tiedostot, joiden nimi alkaa pisteellä (”.”).</translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Näytä aina viimeisenä tiedostot, jotka alkavat pisteellä (”.”).</translation>
     </message>
     <message>
@@ -3427,7 +3427,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished">Näytä tiedostot, joiden nimi alkaa pisteellä (”.”).</translation>
     </message>
     <message>
@@ -3467,7 +3467,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished">Näytä aina viimeisenä tiedostot, jotka alkavat pisteellä (”.”).</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-fr.ts
+++ b/translations/harbour-file-browser-fr.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3429,7 +3429,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-hu.ts
+++ b/translations/harbour-file-browser-hu.ts
@@ -1251,7 +1251,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1311,7 +1311,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3393,7 +3393,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3433,7 +3433,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-id.ts
+++ b/translations/harbour-file-browser-id.ts
@@ -1251,7 +1251,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1311,7 +1311,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3393,7 +3393,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3433,7 +3433,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-it.ts
+++ b/translations/harbour-file-browser-it.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Mostra i file con nomi che iniziano con un punto (&quot;.&quot;).</translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Mostra sempre i file che iniziano con un punto (&quot;.&quot;) alla fine dell&apos;elenco file.</translation>
     </message>
     <message>
@@ -3429,7 +3429,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Mostra file con nomi che iniziamo con un punto (&quot;.&quot;).</translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Mostra sempre per ultimi i file con un punto (&quot;.&quot;).</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-lt.ts
+++ b/translations/harbour-file-browser-lt.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3463,7 +3463,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3503,7 +3503,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-nb_NO.ts
+++ b/translations/harbour-file-browser-nb_NO.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3429,7 +3429,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-nl.ts
+++ b/translations/harbour-file-browser-nl.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3429,7 +3429,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-nl_BE.ts
+++ b/translations/harbour-file-browser-nl_BE.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3429,7 +3429,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-pl.ts
+++ b/translations/harbour-file-browser-pl.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3463,7 +3463,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3503,7 +3503,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-ro.ts
+++ b/translations/harbour-file-browser-ro.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3463,7 +3463,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3503,7 +3503,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-ru.ts
+++ b/translations/harbour-file-browser-ru.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Показывать файлы с именами, начинающимися с точки (“.”).</translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Всегда показывайте файлы, начинающиеся с точки (“.”) в конце списка файлов.</translation>
     </message>
     <message>
@@ -3465,7 +3465,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Показывать файлы с именами, начинающимися с точки (“.”).</translation>
     </message>
     <message>
@@ -3505,7 +3505,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Всегда показывайте файлы, начинающиеся с точки (“.”) в конце списка файлов.</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-sk.ts
+++ b/translations/harbour-file-browser-sk.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Zobraziť súbory s názvami začínajúcimi bodkou („.“).</translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Súbory začínajúce bodkou („.“) zobrazovať vždy na konci zoznamu súborov.</translation>
     </message>
     <message>
@@ -3465,7 +3465,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Zobraziť súbory s názvami začínajúcimi bodkou („.“).</translation>
     </message>
     <message>
@@ -3505,7 +3505,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Súbory začínajúce bodkou („.“) zobrazovať vždy na konci zoznamu súborov.</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-sr.ts
+++ b/translations/harbour-file-browser-sr.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3463,7 +3463,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3503,7 +3503,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-sv.ts
+++ b/translations/harbour-file-browser-sv.ts
@@ -1268,7 +1268,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Visa filer med namn som börjar med punkt (&quot;.&quot;).</translation>
     </message>
     <message>
@@ -1328,7 +1328,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Visa alltid filer som börjar med en punkt (“.”), sist i fillistan.</translation>
     </message>
     <message>
@@ -3429,7 +3429,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Visa filer med namn som börjar med punkt (&quot;.&quot;).</translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Visa alltid filer som börjar med punkt (&quot;.&quot;) i slutet av fillistan.</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-tr.ts
+++ b/translations/harbour-file-browser-tr.ts
@@ -1251,7 +1251,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Nokta (&quot;.&quot;) ile başlayan isimlere sahip dosyaları göster.</translation>
     </message>
     <message>
@@ -1311,7 +1311,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Nokta (&quot;.&quot;) ile başlayan dosyaları her zaman dosya listesinin sonunda göster.</translation>
     </message>
     <message>
@@ -3393,7 +3393,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished">Nokta (&quot;.&quot;) ile başlayan isimlere sahip dosyaları göster.</translation>
     </message>
     <message>
@@ -3433,7 +3433,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished">Nokta (&quot;.&quot;) ile başlayan dosyaları her zaman dosya listesinin sonunda göster.</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-uk.ts
+++ b/translations/harbour-file-browser-uk.ts
@@ -1285,7 +1285,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Показувати файли з іменами, що починаються з крапки (&quot;.&quot;).</translation>
     </message>
     <message>
@@ -1345,7 +1345,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Завжди показувати файли, що починаються з крапки (&quot;.&quot;) в кінці списку файлів.</translation>
     </message>
     <message>
@@ -3465,7 +3465,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>Показувати файли з іменами, що починаються з крапки (&quot;.&quot;).</translation>
     </message>
     <message>
@@ -3505,7 +3505,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>Завжди показувати файли, що починаються з крапки (&quot;.&quot;) в кінці списку файлів.</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser-zh_CN.ts
+++ b/translations/harbour-file-browser-zh_CN.ts
@@ -1251,7 +1251,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>显示名称开头为半角句号（“.”）的文件。</translation>
     </message>
     <message>
@@ -1311,7 +1311,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>名称开头带句点（“.”）的文件总在文件列表末尾显示。</translation>
     </message>
     <message>
@@ -3393,7 +3393,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation>显示文件名开头为句点（“.”）的文件。</translation>
     </message>
     <message>
@@ -3433,7 +3433,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation>名称开头带句点（“.”）的文件总在文件列表末尾显示。</translation>
     </message>
 </context>

--- a/translations/harbour-file-browser.ts
+++ b/translations/harbour-file-browser.ts
@@ -1251,7 +1251,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="106"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1311,7 +1311,7 @@
     </message>
     <message>
         <location filename="../qml/pages/GlobalSettingsPage.qml" line="147"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3391,7 +3391,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="132"/>
-        <source>Show files with names starting with a full stop (“.”).</source>
+        <source>Show files with names starting with a dot (“.”).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3431,7 +3431,7 @@ exposure program</extracomment>
     </message>
     <message>
         <location filename="../qml/pages/ViewSettingsPage.qml" line="169"/>
-        <source>Always show files starting with a full stop (“.”) at the end of the file list.</source>
+        <source>Always show files starting with a dot (“.”) at the end of the file list.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
> In computing, it is called a dot.

Wikipedia is not *best* source of all information, however, in this case under the [Computing](https://en.wikipedia.org/wiki/Full_stop#Computing) section of *Full stop* article, the word “dot” is prefered (such as ‘dot com’, ‘dotfiles’, & so on). As mentioned at the top of the article, the word “period” is much more common in North American English (which I am a speaker of) so the term “full stop” was unexpected to see in the UI. Historically, ‘full stop’ was used for the terminating punctuation; it is unfortunate that Unicode has chosen the name `FULL STOP`. Seeing as “Behavior” (US spelling) is one section heading it is rather inconsistent to be mixing dialects.

`sed -i "s/full stop (/dot (/g" ./**/*.ts ./**/*.qml`

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.