### PR TITLE
Fixed time format in italian translations

### DIFF
--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -206,7 +206,8 @@ A.AboutPageBase {
                     title: qsTr("Italian")
                     entries: [
                         "Tichy",
-                        "luca rastelli"
+                        "luca rastelli",
+                        "Mauro Scomparin"
                     ]
                 },
                 A.ContributionGroup {

--- a/translations/harbour-file-browser-it.ts
+++ b/translations/harbour-file-browser-it.ts
@@ -2729,11 +2729,11 @@ exposure program</extracomment>
     </message>
     <message>
         <source>dd MMM yyyy, hh:mm:ss t</source>
-        <translation type="vanished">gg MMM aaaa, hh:mm:ss t</translation>
+        <translation type="vanished">dd MMM aaaa, hh:mm:ss t</translation>
     </message>
     <message>
         <source>dd.MM.yy, hh:mm</source>
-        <translation type="vanished">gg.MM.yy, hh:mm</translation>
+        <translation type="vanished">dd.MM.yy, hh:mm</translation>
     </message>
     <message>
         <location filename="../src/globals.cpp" line="122"/>
@@ -2745,13 +2745,13 @@ exposure program</extracomment>
         <location filename="../src/globals.cpp" line="125"/>
         <source>dd MMM yyyy, hh:mm:ss t</source>
         <comment>Date and time format. Use what&apos;s common in your language. See https://doc.qt.io/archives/qt-5.15/qml-qtqml-date.html#format-strings for details.</comment>
-        <translation type="unfinished">gg MMM aaaa, hh:mm:ss t</translation>
+        <translation type="unfinished">dd MMM aaaa, hh:mm:ss t</translation>
     </message>
     <message>
         <location filename="../src/globals.cpp" line="127"/>
         <source>dd.MM.yy, hh:mm</source>
         <comment>Date and format. Use what&apos;s common in your language. See https://doc.qt.io/archives/qt-5.15/qml-qtqml-date.html#format-strings for details.</comment>
-        <translation type="unfinished">gg.MM.yy, hh:mm</translation>
+        <translation type="unfinished">dd.MM.yy, hh:mm</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-file-browser-it.ts
+++ b/translations/harbour-file-browser-it.ts
@@ -2725,33 +2725,33 @@ exposure program</extracomment>
     <name>QObject</name>
     <message>
         <source>hh:mm:ss</source>
-        <translation type="vanished">oo:mm:ss</translation>
+        <translation type="vanished">hh:mm:ss</translation>
     </message>
     <message>
         <source>dd MMM yyyy, hh:mm:ss t</source>
-        <translation type="vanished">gg MMM aaaa, oo:mm:ss t</translation>
+        <translation type="vanished">gg MMM aaaa, hh:mm:ss t</translation>
     </message>
     <message>
         <source>dd.MM.yy, hh:mm</source>
-        <translation type="vanished">gg.MM.yy, oo:mm</translation>
+        <translation type="vanished">gg.MM.yy, hh:mm</translation>
     </message>
     <message>
         <location filename="../src/globals.cpp" line="122"/>
         <source>hh:mm:ss</source>
         <comment>Time format. Use what&apos;s common in your language. See https://doc.qt.io/archives/qt-5.15/qml-qtqml-date.html#format-strings for details.</comment>
-        <translation type="unfinished">oo:mm:ss</translation>
+        <translation type="unfinished">hh:mm:ss</translation>
     </message>
     <message>
         <location filename="../src/globals.cpp" line="125"/>
         <source>dd MMM yyyy, hh:mm:ss t</source>
         <comment>Date and time format. Use what&apos;s common in your language. See https://doc.qt.io/archives/qt-5.15/qml-qtqml-date.html#format-strings for details.</comment>
-        <translation type="unfinished">gg MMM aaaa, oo:mm:ss t</translation>
+        <translation type="unfinished">gg MMM aaaa, hh:mm:ss t</translation>
     </message>
     <message>
         <location filename="../src/globals.cpp" line="127"/>
         <source>dd.MM.yy, hh:mm</source>
         <comment>Date and format. Use what&apos;s common in your language. See https://doc.qt.io/archives/qt-5.15/qml-qtqml-date.html#format-strings for details.</comment>
-        <translation type="unfinished">gg.MM.yy, oo:mm</translation>
+        <translation type="unfinished">gg.MM.yy, hh:mm</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
The date/time is always showing "oo:" instead of the hour in the file details.

Changed all occurences of  "oo:mm" to "hh:mm" in the italian translations  as specified in
https://doc.qt.io/archives/qt-5.15/qml-qtqml-date.html#details.

Added myself to the list of the translators.